### PR TITLE
Module cpu

### DIFF
--- a/src/cli/daemon.cpp
+++ b/src/cli/daemon.cpp
@@ -8,6 +8,7 @@
 #include <csignal>
 #include <fstream>
 #include <paths.hpp>
+#include "cpu.h"
 #include "scheduler.h"
 #include "system.h"
 
@@ -56,15 +57,18 @@ void daemon() {
 
     // Initialize modules
     SystemInfo sysInfo(eventBus, std::chrono::seconds(1));
+    CPUInfo cpuInfo(eventBus, std::chrono::seconds(1));
 
     // Initialize scheduler for light tasks
     Scheduler scheduler;
     scheduler.add(&sysInfo);
+    scheduler.add(&cpuInfo);
 
     // Add static resources
     server.addStaticResource(&sysInfo);
+    server.addStaticResource(&cpuInfo);
 
-    // Run server
+    // Run servers
     server.run(9001);
 
     // Start scheduler

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(nodewatcher_linux STATIC
     modules/light_module.cpp
     modules/scheduler/scheduler.cpp
     modules/system/system.cpp
+    modules/cpu/cpu.cpp
 )
 
 target_include_directories(nodewatcher_linux PUBLIC
@@ -11,6 +12,7 @@ target_include_directories(nodewatcher_linux PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/modules
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/scheduler
     ${CMAKE_CURRENT_SOURCE_DIR}/modules/system
+    ${CMAKE_CURRENT_SOURCE_DIR}/modules/cpu
 )
 
 target_link_libraries(nodewatcher_linux PUBLIC

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_library(STATGRAB_LIBRARY statgrab REQUIRED)
+
 add_library(nodewatcher_linux STATIC
     files/api_keys.cpp
     modules/static_resource.cpp
@@ -16,6 +18,8 @@ target_include_directories(nodewatcher_linux PUBLIC
 )
 
 target_link_libraries(nodewatcher_linux PUBLIC
-    nodewatcher_server
+    nodewatcher_messages
+    nodewatcher_events
     nlohmann_json::nlohmann_json
+    ${STATGRAB_LIBRARY}
 )

--- a/src/linux/CMakeLists.txt
+++ b/src/linux/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_library(STATGRAB_LIBRARY statgrab REQUIRED)
-
 add_library(nodewatcher_linux STATIC
     files/api_keys.cpp
     modules/static_resource.cpp
@@ -21,5 +19,4 @@ target_link_libraries(nodewatcher_linux PUBLIC
     nodewatcher_messages
     nodewatcher_events
     nlohmann_json::nlohmann_json
-    ${STATGRAB_LIBRARY}
 )

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -1,4 +1,5 @@
 #include <cpu.h>
+#include <statgrab.h>
 #include <sys/utsname.h>
 #include <fstream>
 #include <json.hpp>
@@ -106,4 +107,14 @@ void CPUInfo::getCPULoadAvg(double& load1, double& load5, double& load15) {
     load1 = load[0];
     load5 = load[1];
     load15 = load[2];
+}
+
+double CPUInfo::getCpuUsage() {
+    size_t count = 0;
+    sg_cpu_stats* cpu = sg_get_cpu_stats(&count);
+
+    if (!cpu || count == 0)
+        return 0.0;
+
+    return 100.0 - cpu[0].idle - cpu[0].iowait;
 }

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -1,4 +1,5 @@
 #include <cpu.h>
+#include <sys/utsname.h>
 #include <fstream>
 #include <json.hpp>
 
@@ -39,11 +40,27 @@ void CPUInfo::getCPUModel() {
 }
 
 void CPUInfo::getCPUArchitecture() {
-    // Implementation to retrieve CPU architecture
+    struct utsname u{};
+    if (uname(&u) == 0)
+        cpu_architecture_ = u.machine;  // np. x86_64, aarch64, armv7l
+    else
+        cpu_architecture_ = "unknown";
 }
 
 void CPUInfo::getCPUMaxFrequency() {
-    // Implementation to retrieve CPU max frequency
+    std::ifstream file("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
+    long freq_khz = 0;
+
+    if (!(file >> freq_khz) || freq_khz <= 0) {
+        cpu_max_frequency_ = "0.000";
+        return;
+    }
+
+    double freq_mhz = freq_khz / 1000.0;
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(3) << freq_mhz;
+    cpu_max_frequency_ = oss.str();
 }
 
 void CPUInfo::getCPUCores() {

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -68,5 +68,5 @@ void CPUInfo::getCPUCores() {
 }
 
 void CPUInfo::getCPUThreads() {
-    // Implementation to retrieve number of CPU threads
+    cpu_threads_ = sysconf(_SC_NPROCESSORS_ONLN);
 }

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -1,5 +1,6 @@
 #include <cpu.h>
-#include "json.hpp"
+#include <fstream>
+#include <json.hpp>
 
 CPUInfo::CPUInfo(EventBus& eventBus, std::chrono::milliseconds period)
     : eventBus_(eventBus), period_(period) {
@@ -25,7 +26,16 @@ std::chrono::milliseconds CPUInfo::period() {
 }
 
 void CPUInfo::getCPUModel() {
-    // Implementation to retrieve CPU model
+    std::ifstream file("/proc/cpuinfo");
+    std::string line;
+
+    cpu_model_ = "Unknown";
+
+    while (std::getline(file, line)) {
+        if (line.rfind("model name", 0) == 0) {
+            cpu_model_ = line.substr(line.find(':') + 2);
+        }
+    }
 }
 
 void CPUInfo::getCPUArchitecture() {

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -22,7 +22,16 @@ message::MessageVariantOUT CPUInfo::getStaticData() {
 }
 
 void CPUInfo::collect() {
-    // Implementation for collecting dynamic CPU data
+    message::CpuInfo cpu_info;
+    double load1, load5, load15;
+    getCPULoadAvg(load1, load5, load15);
+    cpu_info.cpu_load_avg_1min = load1;
+    cpu_info.cpu_load_avg_5min = load5;
+    cpu_info.cpu_load_avg_15min = load15;
+    cpu_info.cpu_usage = getCpuUsage();
+    cpu_info.per_core_usage = getPerCoreUsage();
+    cpu_info.cpu_frequency = getCPUFrequency();
+    eventBus_.publish(cpu_info);
 }
 
 std::chrono::milliseconds CPUInfo::period() {

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -93,3 +93,17 @@ void CPUInfo::getCPUCores() {
 void CPUInfo::getCPUThreads() {
     cpu_threads_ = sysconf(_SC_NPROCESSORS_ONLN);
 }
+
+void CPUInfo::getCPULoadAvg(double& load1, double& load5, double& load15) {
+    double load[3];
+    if (getloadavg(load, 3) != 3) {
+        load1 = 0.0;
+        load5 = 0.0;
+        load15 = 0.0;
+        return;
+    }
+
+    load1 = load[0];
+    load5 = load[1];
+    load15 = load[2];
+}

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -1,0 +1,45 @@
+#include <cpu.h>
+#include "json.hpp"
+
+CPUInfo::CPUInfo(EventBus& eventBus, std::chrono::milliseconds period)
+    : eventBus_(eventBus), period_(period) {
+    getCPUModel();
+    getCPUArchitecture();
+    getCPUMaxFrequency();
+    getCPUCores();
+    getCPUThreads();
+}
+
+message::MessageVariantOUT CPUInfo::getStaticData() {
+    message::CpuInfoStatic cpu_info_static(cpu_model_, cpu_architecture_,
+                                           cpu_max_frequency_, cpu_cores_, cpu_threads_);
+    return cpu_info_static;
+}
+
+void CPUInfo::collect() {
+    // Implementation for collecting dynamic CPU data
+}
+
+std::chrono::milliseconds CPUInfo::period() {
+    return period_;
+}
+
+void CPUInfo::getCPUModel() {
+    // Implementation to retrieve CPU model
+}
+
+void CPUInfo::getCPUArchitecture() {
+    // Implementation to retrieve CPU architecture
+}
+
+void CPUInfo::getCPUMaxFrequency() {
+    // Implementation to retrieve CPU max frequency
+}
+
+void CPUInfo::getCPUCores() {
+    // Implementation to retrieve number of CPU cores
+}
+
+void CPUInfo::getCPUThreads() {
+    // Implementation to retrieve number of CPU threads
+}

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -50,18 +50,14 @@ void CPUInfo::getCPUArchitecture() {
 
 void CPUInfo::getCPUMaxFrequency() {
     std::ifstream file("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq");
-    long freq_khz = 0;
+    int freq = 0;
 
-    if (!(file >> freq_khz) || freq_khz <= 0) {
-        cpu_max_frequency_ = "0.000";
+    if (!(file >> freq) || freq <= 0) {
+        cpu_max_frequency_ = 0;
         return;
     }
 
-    double freq_mhz = freq_khz / 1000.0;
-
-    std::ostringstream oss;
-    oss << std::fixed << std::setprecision(3) << freq_mhz;
-    cpu_max_frequency_ = oss.str();
+    cpu_max_frequency_ = freq;
 }
 
 void CPUInfo::getCPUCores() {

--- a/src/linux/modules/cpu/cpu.cpp
+++ b/src/linux/modules/cpu/cpu.cpp
@@ -22,15 +22,10 @@ message::MessageVariantOUT CPUInfo::getStaticData() {
 }
 
 void CPUInfo::collect() {
-    message::CpuInfo cpu_info;
     double load1, load5, load15;
     getCPULoadAvg(load1, load5, load15);
-    cpu_info.cpu_load_avg_1min = load1;
-    cpu_info.cpu_load_avg_5min = load5;
-    cpu_info.cpu_load_avg_15min = load15;
-    cpu_info.cpu_usage = getCpuUsage();
-    cpu_info.per_core_usage = getPerCoreUsage();
-    cpu_info.cpu_frequency = getCPUFrequency();
+    message::CpuInfo cpu_info(load1, load5, load15, getCpuUsage(), getPerCoreUsage(),
+                              getCPUFrequency());
     eventBus_.publish(cpu_info);
 }
 

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -6,6 +6,10 @@
 #include <static_resource.h>
 #include <string>
 
+struct CpuTimes {
+    long long user, nice, system, idle, iowait, irq, softirq, steal;
+};
+
 class CPUInfo : public IStaticResource, public ILightModule {
 public:
     CPUInfo(EventBus& eventBus, std::chrono::milliseconds period);
@@ -27,6 +31,10 @@ private:
     std::vector<double> getPerCoreUsage();
     int getCPUFrequency();
 
+    // Helpers
+    CpuTimes readCpuTimes(int core = -1);
+    double calcCpuUsage(const CpuTimes& a, const CpuTimes& b);
+
     EventBus& eventBus_;
     std::chrono::milliseconds period_;
 
@@ -35,6 +43,10 @@ private:
     int cpu_max_frequency_;
     int cpu_cores_;
     int cpu_threads_;
+    bool cpu_initialized_ = false;
+    bool per_core_initialized_ = false;
+    CpuTimes previous_total_times_;
+    std::vector<CpuTimes> previous_per_core_times_;
 };
 
 #endif  // CPU_H

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -22,6 +22,7 @@ private:
     void getCPUThreads();
 
     // Dynamic system information retrieval methods
+    void getCPULoadAvg(double& load1, double& load5, double& load15);
 
     EventBus& eventBus_;
     std::chrono::milliseconds period_;

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -24,6 +24,8 @@ private:
     // Dynamic system information retrieval methods
     void getCPULoadAvg(double& load1, double& load5, double& load15);
     double getCpuUsage();
+    std::vector<double> getPerCoreUsage();
+    int getCPUFrequency();
 
     EventBus& eventBus_;
     std::chrono::milliseconds period_;

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -23,6 +23,7 @@ private:
 
     // Dynamic system information retrieval methods
     void getCPULoadAvg(double& load1, double& load5, double& load15);
+    double getCpuUsage();
 
     EventBus& eventBus_;
     std::chrono::milliseconds period_;

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -1,0 +1,34 @@
+#ifndef CPU_H
+#define CPU_H
+
+#include <event_bus.h>
+#include <light_module.h>
+#include <static_resource.h>
+#include <string>
+
+class CPUInfo : public IStaticResource, public ILightModule {
+public:
+    CPUInfo(EventBus& eventBus, std::chrono::milliseconds period);
+    message::MessageVariantOUT getStaticData() override;
+    void collect() override;
+    std::chrono::milliseconds period() override;
+
+private:
+    // Static system information retrieval methods
+    void getCPUModel();
+    void getCPUArchitecture();
+    void getCPUMaxFrequency();
+    void getCPUCores();
+    void getCPUThreads();
+
+    EventBus& eventBus_;
+    std::chrono::milliseconds period_;
+
+    std::string cpu_model_;
+    std::string cpu_architecture_;
+    std::string cpu_max_frequency_;
+    int cpu_cores_;
+    int cpu_threads_;
+};
+
+#endif  // CPU_H

--- a/src/linux/modules/cpu/cpu.h
+++ b/src/linux/modules/cpu/cpu.h
@@ -21,12 +21,14 @@ private:
     void getCPUCores();
     void getCPUThreads();
 
+    // Dynamic system information retrieval methods
+
     EventBus& eventBus_;
     std::chrono::milliseconds period_;
 
     std::string cpu_model_;
     std::string cpu_architecture_;
-    std::string cpu_max_frequency_;
+    int cpu_max_frequency_;
     int cpu_cores_;
     int cpu_threads_;
 };

--- a/src/linux/modules/system/system.h
+++ b/src/linux/modules/system/system.h
@@ -2,10 +2,10 @@
 #define SYSTEM_H
 
 #include <event_bus.h>
+#include <light_module.h>
 #include <static_resource.h>
 #include <json.hpp>
 #include <string>
-#include "light_module.h"
 
 class SystemInfo : public IStaticResource, public ILightModule {
 public:

--- a/src/server/json/json.hpp
+++ b/src/server/json/json.hpp
@@ -16,6 +16,7 @@ namespace message {
         SYSTEM_INFO_STATIC = 4,
         SYSTEM_INFO = 5,
         CPU_INFO_STATIC = 6,
+        CPU_INFO = 7,
     };
 
     NLOHMANN_JSON_SERIALIZE_ENUM(Type,
@@ -28,6 +29,7 @@ namespace message {
                                      {Type::SYSTEM_INFO_STATIC, "SYSTEM_INFO_STATIC"},
                                      {Type::SYSTEM_INFO, "SYSTEM_INFO"},
                                      {Type::CPU_INFO_STATIC, "CPU_INFO_STATIC"},
+                                     {Type::CPU_INFO, "CPU_INFO"},
                                  })
 
     struct Message {
@@ -146,7 +148,7 @@ namespace message {
                 double cpu_usage,
                 const std::vector<double>& per_core_usage,
                 int cpu_frequency)
-            : Message(Type::SYSTEM_INFO),
+            : Message(Type::CPU_INFO),
               cpu_load_avg_1min(cpu_load_avg_1min),
               cpu_load_avg_5min(cpu_load_avg_5min),
               cpu_load_avg_15min(cpu_load_avg_15min),

--- a/src/server/json/json.hpp
+++ b/src/server/json/json.hpp
@@ -132,7 +132,36 @@ namespace message {
                                        cpu_cores,
                                        cpu_threads);
 
-    struct CpuInfo : public Message {};
+    struct CpuInfo : public Message {
+        double cpu_load_avg_1min;
+        double cpu_load_avg_5min;
+        double cpu_load_avg_15min;
+        double cpu_usage;
+        std::vector<double> per_core_usage;
+        int cpu_frequency;
+        CpuInfo() = default;
+        CpuInfo(double cpu_load_avg_1min,
+                double cpu_load_avg_5min,
+                double cpu_load_avg_15min,
+                double cpu_usage,
+                const std::vector<double>& per_core_usage,
+                int cpu_frequency)
+            : Message(Type::SYSTEM_INFO),
+              cpu_load_avg_1min(cpu_load_avg_1min),
+              cpu_load_avg_5min(cpu_load_avg_5min),
+              cpu_load_avg_15min(cpu_load_avg_15min),
+              cpu_usage(cpu_usage),
+              per_core_usage(per_core_usage),
+              cpu_frequency(cpu_frequency) {}
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CpuInfo,
+                                       type,
+                                       cpu_load_avg_1min,
+                                       cpu_load_avg_5min,
+                                       cpu_load_avg_15min,
+                                       cpu_usage,
+                                       per_core_usage,
+                                       cpu_frequency);
 }  // namespace message
 
 // Utility functions for parsing and serializing messages
@@ -144,7 +173,8 @@ namespace message {
                                            AuthResult,
                                            SystemInfoStatic,
                                            SystemInfo,
-                                           CpuInfoStatic>;
+                                           CpuInfoStatic,
+                                           CpuInfo>;
 
     using MessageVariant = std::variant<Error,
                                         AuthChallenge,
@@ -152,7 +182,8 @@ namespace message {
                                         AuthResult,
                                         SystemInfoStatic,
                                         SystemInfo,
-                                        CpuInfoStatic>;
+                                        CpuInfoStatic,
+                                        CpuInfo>;
 
     using ParserFn = message::MessageVariantIN (*)(const nlohmann::json&);
 

--- a/src/server/json/json.hpp
+++ b/src/server/json/json.hpp
@@ -15,6 +15,7 @@ namespace message {
         AUTH_RESULT = 3,
         SYSTEM_INFO_STATIC = 4,
         SYSTEM_INFO = 5,
+        CPU_INFO_STATIC = 6,
     };
 
     NLOHMANN_JSON_SERIALIZE_ENUM(Type,
@@ -26,6 +27,7 @@ namespace message {
                                      {Type::AUTH_RESULT, "AUTH_RESULT"},
                                      {Type::SYSTEM_INFO_STATIC, "SYSTEM_INFO_STATIC"},
                                      {Type::SYSTEM_INFO, "SYSTEM_INFO"},
+                                     {Type::CPU_INFO_STATIC, "CPU_INFO_STATIC"},
                                  })
 
     struct Message {
@@ -102,21 +104,53 @@ namespace message {
             : Message(Type::SYSTEM_INFO), uptime(uptime), local_time(local_time) {}
     };
     NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SystemInfo, type, uptime, local_time);
+
+    struct CpuInfoStatic : public Message {
+        std::string cpu_model;
+        std::string cpu_architecture;
+        std::string cpu_max_frequency;
+        int cpu_cores;
+        int cpu_threads;
+        CpuInfoStatic() = default;
+        CpuInfoStatic(const std::string& cpu_model,
+                      const std::string& cpu_architecture,
+                      const std::string& cpu_max_frequency,
+                      int cpu_cores,
+                      int cpu_threads)
+            : Message(Type::CPU_INFO_STATIC),
+              cpu_model(cpu_model),
+              cpu_architecture(cpu_architecture),
+              cpu_max_frequency(cpu_max_frequency),
+              cpu_cores(cpu_cores),
+              cpu_threads(cpu_threads) {}
+    };
+    NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CpuInfoStatic,
+                                       type,
+                                       cpu_model,
+                                       cpu_architecture,
+                                       cpu_max_frequency,
+                                       cpu_cores,
+                                       cpu_threads);
 }  // namespace message
 
 // Utility functions for parsing and serializing messages
 namespace message {
 
     using MessageVariantIN = std::variant<Error, AuthResponse>;
-    using MessageVariantOUT =
-        std::variant<Error, AuthChallenge, AuthResult, SystemInfoStatic, SystemInfo>;
+    using MessageVariantOUT = std::variant<Error,
+                                           AuthChallenge,
+                                           AuthResult,
+                                           SystemInfoStatic,
+                                           SystemInfo,
+                                           CpuInfoStatic>;
 
     using MessageVariant = std::variant<Error,
                                         AuthChallenge,
                                         AuthResponse,
                                         AuthResult,
                                         SystemInfoStatic,
-                                        SystemInfo>;
+                                        SystemInfo,
+                                        CpuInfoStatic>;
 
     using ParserFn = message::MessageVariantIN (*)(const nlohmann::json&);
 

--- a/src/server/json/json.hpp
+++ b/src/server/json/json.hpp
@@ -108,13 +108,13 @@ namespace message {
     struct CpuInfoStatic : public Message {
         std::string cpu_model;
         std::string cpu_architecture;
-        std::string cpu_max_frequency;
+        int cpu_max_frequency;
         int cpu_cores;
         int cpu_threads;
         CpuInfoStatic() = default;
         CpuInfoStatic(const std::string& cpu_model,
                       const std::string& cpu_architecture,
-                      const std::string& cpu_max_frequency,
+                      int cpu_max_frequency,
                       int cpu_cores,
                       int cpu_threads)
             : Message(Type::CPU_INFO_STATIC),
@@ -131,6 +131,8 @@ namespace message {
                                        cpu_max_frequency,
                                        cpu_cores,
                                        cpu_threads);
+
+    struct CpuInfo : public Message {};
 }  // namespace message
 
 // Utility functions for parsing and serializing messages


### PR DESCRIPTION
This pull request adds a new CPU information module to the Linux nodewatcher agent, enabling collection and reporting of both static and dynamic CPU metrics. The changes introduce the `CPUInfo` class, integrate it with the scheduler and server, and extend the JSON message schema to support CPU-related data.

**Key changes:**

**1. New CPU Monitoring Module**
- Added the `CPUInfo` class (`cpu.cpp`, `cpu.h`) to collect static (model, architecture, max frequency, core/thread count) and dynamic (load averages, usage, per-core usage, current frequency) CPU information. Implements both `IStaticResource` and `ILightModule` interfaces for integration with the agent's resource and scheduling system. [[1]](diffhunk://#diff-31206de7b91ce6a0a14f280ffbd44a15ebc5a66b965d805aaea3f04c68208ad7R1-R201) [[2]](diffhunk://#diff-7472ea4161d975490d13561b37bbac6b4224b0ecd0b0f46bc7d453b1f8fe3326R1-R52)

**2. Integration with Daemon and Scheduler**
- Integrated the new `CPUInfo` module into the main daemon: it is instantiated, registered with the scheduler, and exposed as a static resource, similar to the existing `SystemInfo` module. [[1]](diffhunk://#diff-342f866789a88956dbdb13a98988d0dabdb25dd6e39942bead06d6a139515e63R11) [[2]](diffhunk://#diff-342f866789a88956dbdb13a98988d0dabdb25dd6e39942bead06d6a139515e63R60-R71)

**3. Build System Updates**
- Updated the CMake configuration to compile and link the new CPU module and its dependencies.

**4. JSON Message Schema Extension**
- Extended the `message` namespace in `json.hpp` to include new message types and structures for CPU static and dynamic information (`CpuInfoStatic`, `CpuInfo`). Updated serialization/deserialization and message variant types to support these new messages. [[1]](diffhunk://#diff-ccf3b784e3ce4805ea7cb5ef1ee94e2ae33ebf1a5cd57ca6fb8c04ffb8cb06e3R18-R19) [[2]](diffhunk://#diff-ccf3b784e3ce4805ea7cb5ef1ee94e2ae33ebf1a5cd57ca6fb8c04ffb8cb06e3R31-R32) [[3]](diffhunk://#diff-ccf3b784e3ce4805ea7cb5ef1ee94e2ae33ebf1a5cd57ca6fb8c04ffb8cb06e3R109-R188)

**5. Minor Header Cleanup**
- Minor include order fix in `system.h` to improve consistency.